### PR TITLE
Enh: add portal_url install arg

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -11,6 +11,7 @@ BABEL_TRANSLATION_DIRECTORIES = "locales"
 # Customization
 CUSTOM = {
     "name": "__PROJECT_NAME__",
+    "portal_url": "__PORTAL_URL__",
     "contact_url": "__CONTACT_URL__",
     "logo": "__LOGO__",
     "favicon": "__FAVICON__",

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Pepettes"
 description.en = "Simple donation form with stripe"
 description.fr = "Simple formulaire de don avec stripe"
 
-version = "1.2~ynh1"
+version = "1.3~ynh1"
 
 maintainers = ["ljf"]
 
@@ -91,8 +91,8 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    url = "https://github.com/YunoHost/pepettes/archive/refs/tags/v1.2.tar.gz"
-    sha256 = "eed171d58451c890a25876d937bbe5ddcdea48e7525bdc7dccbbddf7aadd7736"
+    url = "https://github.com/YunoHost/pepettes/archive/refs/tags/v1.3.tar.gz"
+    sha256 = "1088345596362f57b24cdcf87bff71ffa994617ca8451c0d72e675a239aa0cc1"
     autoupdate.strategy = "latest_github_release"
 
     [resources.ports]

--- a/manifest.toml
+++ b/manifest.toml
@@ -43,8 +43,8 @@ ram.runtime = "50M"
     default = ""
 
     [install.contact_url]
-    ask.en = "Indicate a link to contact you to ask for stopping recuring payment"
-    ask.fr = "Indiquez un lien pour vous contacter pour arréter les paiements récurrents"
+    ask.en = "Indicate a link to contact you"
+    ask.fr = "Indiquez un lien pour vous contacter"
     type = "string"
     default = ""
 
@@ -79,6 +79,15 @@ ram.runtime = "50M"
     help.fr = "Allez sur https://dashboard.stripe.com/products pour créer ces produits de dons"
     type = "string"
     default = "one_time/EUR/price_1IKuPV,recuring/EUR/price_1IKuPV,one_time/USD/price_1IKuPV,recuring/USD/price_1IKuPV"
+
+    [install.portal_url]
+    ask.en = "Indicate a Stripe portal link"
+    ask.fr = "Indiquez un lien vers le portail Stripe"
+    help.en = "activate the portal on https://dashboard.stripe.com/settings/billing/portal to let your donators manage their monthly donation."
+    help.fr = "activez le portail sur https://dashboard.stripe.com/settings/billing/portal pour permettre à vos donateur⋅ices de gérer leur don mensuel."
+    type = "string"
+    default = ""
+    optional = true
 
 [resources]
     [resources.sources.main]


### PR DESCRIPTION
## Problem

- people can't cancel their monthly donation on their own

## Solution

- add a `portal_url` setting with the link displayed in the homepage that lead to the Stripe client portal.

## PR Status

- need upstream's merge of https://github.com/YunoHost/pepettes/pull/13

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
